### PR TITLE
Start API spec, conform gateway to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 ---
 
-### How to build
+## Interfacing
+
+The Corona Network is a decentralized peer-to-peer social network. Instead of a cloud or backend server, this library itself is providing the APIs that thin clients (i.e. mobile user interfaces) rely on. This is done via hosting a local HTTP server that substitutes *"the cloud"*, in reality being a gateway into a distributed world.
+
+For a long rundown behind the model with regard to rationales, privacy concerns and security concerns, please see the [`go-ghostbridge`](https://github.com/ipsn/go-ghostbridge) project. As a quick TL;DR:
+
+* *Emulating* a cloud through a REST API permits us to naturally build a React Native interface on top (see [`rn-coronanet`](https://github.com/coronanet/rn-coronanet)). Crossing over from React Native to Java to C to Go via language bindings is not sustainable.
+* Securing the data traffic between the React Native user interface and the REST API server is done through HTTPS via ephemeral server side SSL certificates injected directly into the client on startup.
+* Securing the API server from unauthenticated access is done through ephemeral API tokens injected directly into the client on startup.
+
+You can check the latest version of the API spec [through Swagger](https://editor.swagger.io/?url=https://raw.githubusercontent.com/coronanet/go-coronanet/master/spec/api.yaml).
+
+## How to build
 
 The Corona Network protocol is written in [Go](https://golang.org/). If you want to contribute to this part of the code, you need to have a valid Go installation. We are also using [Go modules](https://blog.golang.org/using-go-modules), please familiarize yourself with them if they are new to you. You will also need a C compiler as certain dependencies of this project are in C.
 
@@ -17,7 +29,7 @@ $ go get -u golang.org/x/mobile/cmd/gomobile
 $ go get -u golang.org/x/mobile/cmd/gobind
 ```
 
-#### Android
+### Android
 
 To build the Android library archive (`.aar`), you need to have an Android SDK and NDK installed and the `ANDROID_HOME` environment variable correctly set. Please consult the Android docs if you're stuck. You might want to do it through [Android Studio](https://developer.android.com/studio). We're not going to use the Android Studio at all, but it's an easy way to manage your SDKs and Android emulators.
 
@@ -38,11 +50,11 @@ $ ls -al | grep coronanet
 
 Whoa, that final binary size is insane. Yes it is, but it does contain 4 architectures + debug symbols. Long term a proper build system could make things a bit more pleasant. Optimizing app size is not relevant at this phase, simplicity and portability are more useful.
 
-#### iOS
+### iOS
 
 iOS is not planned for the initial MVP to keep the scope smaller. A lot of prerequisite work needs to be done on supporting infra first ([`go-libtor`](https://github.com/ipsn/go-libtor), [`go-ghostbridge`](https://github.com/ipsn/go-ghostbridge), etc), which is wasted time until it's proven to be worth it.
 
-### Contributing
+## Contributing
 
 This project is an experiment.
 
@@ -50,7 +62,7 @@ I'm very grateful for any and all contributions, but you must be aware that ther
 
 The goal of the Corona Network is to be a tiny, *use-case specific decentralized social network with privacy and security* above all else. If it cannot be done within these constraints, it won't be done. **No cloud, no server, no tracking.**
 
-### License
+## License
 
 I don't know. This project contains a lot of my free time and a lot of my past ideas and work distilled down. I'm happy to give it all away for making the world a nicer place, but I am not willing to accept anyone making money off of it. Open to suggestions.
 

--- a/bridge.go
+++ b/bridge.go
@@ -14,7 +14,7 @@ type Bridge struct {
 // NewBridge creates an instance of the ghost bridge, typed such as gomobile to
 // generate a Bridge constructor out of it.
 func NewBridge() (*Bridge, error) {
-	bridge, err := ghostbridge.New(new(backend))
+	bridge, err := ghostbridge.New(new(Backend))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/coronanet/main.go
+++ b/cmd/coronanet/main.go
@@ -1,0 +1,22 @@
+// coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+// This file contains a development server to launch a local coronanet instance
+// without all the mobile integration.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/coronanet/go-coronanet"
+)
+
+var portFlag = flag.Int("port", 4444, "TCP port to launch the API server on")
+
+func main() {
+	flag.Parse()
+	http.ListenAndServe(fmt.Sprintf("localhost:%d", *portFlag), new(coronanet.Backend))
+}

--- a/service.go
+++ b/service.go
@@ -5,10 +5,17 @@ package coronanet
 
 import (
 	"net/http"
+	"strings"
 )
 
 // ServeHTTP implements http.Handler, serving API calls from the mobile UI. It
 // exposes all the functionality of the social network via a RESTful interface
 // for react native on a mobile.
-func (b *backend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (b *Backend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, "/gateway"):
+		b.serveHTTPGateway(w, r)
+	default:
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}
 }

--- a/service_gateway.go
+++ b/service_gateway.go
@@ -1,0 +1,62 @@
+// coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package coronanet
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// gatewayStatus is the response struct sent back to the client when requesting
+// the current status of the Corona Network P2P gateway.
+type gatewayStatus struct {
+	Enabled   bool `json:"enabled"`
+	Connected bool `json:"connected"`
+	Bandwidth struct {
+		Ingress uint64 `json:"ingress"`
+		Egress  uint64 `json:"egress"`
+	} `json:"bandwidth"`
+}
+
+// serveHTTPGateway serves API calls concerning the P2P gateway.
+func (b *Backend) serveHTTPGateway(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		// Retrieve the gateway status, stuff it into the response and abort if
+		// something went horribly wrong.
+		var (
+			status gatewayStatus
+			err    error
+		)
+		status.Enabled, status.Connected, status.Bandwidth.Ingress, status.Bandwidth.Egress, err = b.Status()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// All ok, stream the status and stats over to the client
+		w.Header().Add("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(status)
+
+	case "PUT":
+		// Ping the backend to enable itself, don't care if it's running or not,
+		// keeps things stateless
+		if err := b.Enable(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+
+	case "DELETE":
+		// Ping the backend to disable itself, don't care if it's running or not,
+		// keeps things stateless
+		if err := b.Disable(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}

--- a/spec/api.yaml
+++ b/spec/api.yaml
@@ -1,0 +1,70 @@
+# coronanet - Coronavirus social distancing network
+# Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+openapi: 3.0.1
+
+info:
+  title: Corona Network
+  description: |
+    Restful API for the Corona Network decentralized social network.
+
+    *The Corona Network API is not a globally accessible service, rather a server running locally on your device. The base URL is not a publicly routed domain, but rather a local one existing only on your device (and even on your device only within a process running [go-coronanet](https://github.com/coronanet/go-coronanet)).*
+  version: 0.0.2
+
+externalDocs:
+  description: Corona Network on GitHub
+  url: https://github.com/coronanet
+
+servers:
+  - url: https://corona-network/
+
+tags:
+  - name: Gateway
+    description: Manage the Corona Network P2P gateway
+paths:
+  /gateway:
+    get:
+      summary: Retrieves the current status of the Corona Network gateway
+      responses:
+        500:
+          description: Something unexpected happened, check message
+        200:
+          description: Current status of the gateway
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Flag whether the gateway is actively attempting to maintain connectivity to the Corona Network. A `true` value does not mean that currently there is a live connection, only that the system will eventually establish one.
+                  connected:
+                    type: boolean
+                    description: Flag whether the gateway has an active connection to the Corona Network.
+                  bandwidth:
+                    type: object
+                    description: Network bandwidth used by the node.
+                    properties:
+                      ingress:
+                        type: number
+                        description: Number of bytes downloaded since the gateway was enabled.
+                      egress:
+                        type: number
+                        description: Number of bytes uploaded since the gateway was enabled.
+    put:
+      summary: Requests the gateway to connect to the Corona Network
+      responses:
+        500:
+          description: Something unexpected happened, check message
+        200:
+          description: Network connection will be established async and actively maintained
+          content: {}
+    delete:
+      summary: Requests the gateway to disconnect from the Corona Network
+      responses:
+        500:
+          description: Something unexpected happened, check message
+        200:
+          description: Network connection torn down
+          content: {}
+components: {}


### PR DESCRIPTION
Figured it will be better to make this effort a bit more spec driven. Otherwise I tend to end up with code that only I understand and there's no documentation ;P

This PR creates an initial REST API spec for very basic P2P gateway management. It also updates the existing codebase to actually conform to that spec (yay).

Lastly it create a `development` binary in `cmd/coronanet` to actually allow trying the APIs out without having to bundle everything up into Android. This will probably need a lot of love in the future, bonus points if we can connect to it directly from an Android device (would make development a breeze).