### PR TITLE
Expose service stats/controls for native notifications

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,4 +1,4 @@
-// coronanet - Coronavirus social distancing network
+// go-coronanet - Coronavirus social distancing network
 // Copyright (c) 2020 Péter Szilágyi. All rights reserved.
 
 package coronanet
@@ -16,14 +16,15 @@ import (
 // Backend represents the social network node that can connect to other nodes in
 // the network and exchange information.
 type Backend struct {
-	proxy *tor.Tor // Proxy through the Tor network, nil when offline
+	datadir string   // Data directory to use for Tor and the database
+	proxy   *tor.Tor // Proxy through the Tor network, nil when offline
 
 	lock sync.RWMutex
 }
 
 // newBackend creates a new social network node.
-func newBackend() (*Backend, error) {
-	return &Backend{}, nil
+func newBackend(datadir string) (*Backend, error) {
+	return &Backend{datadir: datadir}, nil
 }
 
 // Enable creates the network proxy into the Tor network.
@@ -40,6 +41,7 @@ func (b *Backend) Enable() error {
 		ProcessCreator:         libtor.Creator,
 		UseEmbeddedControlConn: true,
 		EnableNetwork:          true,
+		DataDir:                b.datadir,
 		DebugWriter:            os.Stderr,
 		NoHush:                 true,
 	})

--- a/bridge.go
+++ b/bridge.go
@@ -1,22 +1,71 @@
-// coronanet - Coronavirus social distancing network
+// go-coronanet - Coronavirus social distancing network
 // Copyright (c) 2020 Péter Szilágyi. All rights reserved.
 
 package coronanet
 
-import "github.com/ipsn/go-ghostbridge"
+import (
+	"github.com/ipsn/go-ghostbridge"
+)
 
 // Bridge is a tiny struct (re)definition so gomobile will export all the built
 // in methods of the underlying ghostbridge.Bridge struct.
 type Bridge struct {
 	*ghostbridge.Bridge
+	backend *Backend
 }
 
 // NewBridge creates an instance of the ghost bridge, typed such as gomobile to
 // generate a Bridge constructor out of it.
-func NewBridge() (*Bridge, error) {
-	bridge, err := ghostbridge.New(new(Backend))
+func NewBridge(datadir string) (*Bridge, error) {
+	backend, err := newBackend(datadir)
 	if err != nil {
 		return nil, err
 	}
-	return &Bridge{bridge}, nil
+	bridge, err := ghostbridge.New(backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Bridge{
+		Bridge:  bridge,
+		backend: backend,
+	}, nil
+}
+
+// GatewayStatus is a simplified status report from the gateway to be used by
+// native notifications on mobile platforms.
+type GatewayStatus struct {
+	Enabled   bool
+	Connected bool
+	Ingress   int64
+	Egress    int64
+}
+
+// GatewayStatus is a pass-through method to allow directly calling Backend.Status
+// via  the mobile library. This is useful for showing native notifications without
+// screwing with HTTP and certificates.
+func (b *Bridge) GatewayStatus() (*GatewayStatus, error) {
+	enabled, connected, ingress, egress, err := b.backend.Status()
+	if err != nil {
+		return nil, err
+	}
+	return &GatewayStatus{
+		Enabled:   enabled,
+		Connected: connected,
+		Ingress:   int64(ingress),
+		Egress:    int64(egress),
+	}, nil
+}
+
+// EnableGateway is a pass-through method to allow directly calling Backend.Enable
+// via  the mobile library. This is useful for showing native notifications without
+// screwing with HTTP and certificates.
+func (b *Bridge) EnableGateway() error {
+	return b.backend.Enable()
+}
+
+// DisableGateway is a pass-through method to allow directly calling Backend.Disable
+// via  the mobile library. This is useful for showing native notifications without
+// screwing with HTTP and certificates.
+func (b *Bridge) DisableGateway() error {
+	return b.backend.Disable()
 }

--- a/cmd/coronanet/main.go
+++ b/cmd/coronanet/main.go
@@ -1,4 +1,4 @@
-// coronanet - Coronavirus social distancing network
+// go-coronanet - Coronavirus social distancing network
 // Copyright (c) 2020 Péter Szilágyi. All rights reserved.
 
 // This file contains a development server to launch a local coronanet instance

--- a/service.go
+++ b/service.go
@@ -1,4 +1,4 @@
-// coronanet - Coronavirus social distancing network
+// go-coronanet - Coronavirus social distancing network
 // Copyright (c) 2020 Péter Szilágyi. All rights reserved.
 
 package coronanet

--- a/service_gateway.go
+++ b/service_gateway.go
@@ -1,4 +1,4 @@
-// coronanet - Coronavirus social distancing network
+// go-coronanet - Coronavirus social distancing network
 // Copyright (c) 2020 Péter Szilágyi. All rights reserved.
 
 package coronanet

--- a/spec/api.yaml
+++ b/spec/api.yaml
@@ -1,4 +1,4 @@
-# coronanet - Coronavirus social distancing network
+# go-coronanet - Coronavirus social distancing network
 # Copyright (c) 2020 Péter Szilágyi. All rights reserved.
 
 openapi: 3.0.1


### PR DESCRIPTION
Currently the gateway service is manageable only via the HTTP REST interface. This is nice in general for React Native, but on Android the notification for the service **needs** to be native code. This PR exposes a few maintenance methods on the library API too to avoid having to pass through HTTP for things than can be done directly anyway.

Perhaps there's a nicer way, we can definitely replace this eventually. For now I just needed to get this out of the way to focus on feasibility tests.

---

The PR also fixes up the backend so it can be passed teh necessary configurations to boot the whole thing up on Android (i.e. configurable data directory).