### PR TITLE
all: add initial PoC pairing mechanism + protocols

### DIFF
--- a/pairer.go
+++ b/pairer.go
@@ -1,0 +1,187 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package coronanet
+
+import (
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/coronanet/go-coronanet/protocol/pairing"
+	"github.com/coronanet/go-coronanet/protocol/system"
+	"github.com/coronanet/go-coronanet/tornet"
+)
+
+// pairer runs the pairing algorithm with a remote peer, hopefully at the end
+// of it resulting in a remote identity.
+type pairer struct {
+	self *tornet.PublicIdentity // Real identity to send to the remote peer
+	peer *tornet.PublicIdentity // Real identity to receive from the remote peer
+
+	channel  *tornet.Node  // Ephemeral pairing channel through the Tor network
+	failure  error         // Failure that occurred during the pairing exchange
+	finished chan struct{} // Notification channel when pairing finishes
+
+	enc *gob.Encoder // Gob encoder for sending messages
+	dec *gob.Decoder // Gob decoder for reading messages
+}
+
+// newPairingServer creates a temporary tornet running a pairing protocol and
+// attempts to exchange the real identities of two peers. Internally it creates
+// an ephemeral identity to advertise on a unique, temporary side channel.
+//
+// The method returns a single public identity that acts as the discovery onion
+// address as well as the authentication TLS certificate for **both** the client
+// and server (essentially a shared secret). It is super unorthodox to reuse the
+// same certificate in both directions, but it avoids having to send 2 identities
+// to the joiner (which would make QR codes quite unwieldy).
+func newPairingServer(gateway tornet.Gateway, id *tornet.PublicIdentity) (*pairer, *tornet.SecretIdentity, error) {
+	// Pairing will be done on an ephemeral channel, create a temporary identity
+	// for it, reusing the same for both directions.
+	secret, err := tornet.GenerateIdentity()
+	if err != nil {
+		return nil, nil, err
+	}
+	// Establish a new temporary tornet to accept the pairing connection on
+	p := &pairer{
+		self:     id,
+		finished: make(chan struct{}, 1),
+	}
+	p.channel = tornet.New(gateway, secret, map[string]*tornet.PublicIdentity{"": secret.Public()}, p.handle)
+	if err := p.channel.StartOnlyServe(); err != nil {
+		return nil, nil, err
+	}
+	return p, secret, nil
+}
+
+// newPairingClient creates a temporary tornet running a pairing protocol and
+// attempts to exchange the real identities of two peers. Internally it uses
+// a pre-distributed ephemeral identity to connect to a temporary side channel.
+func newPairingClient(gateway tornet.Gateway, id *tornet.PublicIdentity, secret *tornet.SecretIdentity) (*pairer, error) {
+	p := &pairer{
+		self:     id,
+		finished: make(chan struct{}, 1),
+	}
+	p.channel = tornet.New(gateway, secret, map[string]*tornet.PublicIdentity{"": secret.Public()}, p.handle)
+	if err := p.channel.StartOnlyDial(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// wait blocks until the pairing is done or the context is cancelled.
+func (p *pairer) wait(ctx context.Context) (*tornet.PublicIdentity, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("context cancelled")
+	case <-p.finished:
+		if p.failure != nil {
+			return nil, p.failure
+		}
+		return p.peer, nil
+	}
+}
+
+// handle is the handler for the pairing protocol.
+//
+// See: https://github.com/coronanet/go-coronanet/blob/master/spec/wire.md
+func (p *pairer) handle(id string, conn net.Conn) (err error) {
+	// Create the gob encoder and decoder
+	p.enc = gob.NewEncoder(conn)
+	p.dec = gob.NewDecoder(conn)
+
+	// Make sure the connection is torn down but send any errors
+	defer conn.Close()
+	defer func() {
+		if err != nil {
+			p.failure = err
+		}
+		close(p.finished)
+	}()
+	// All protocols start with a system handshake, send ours, read theirs
+	errc := make(chan error, 2)
+	go func() {
+		errc <- p.enc.Encode(&system.Handshake{Protocol: pairing.Protocol, Versions: []uint{1}})
+	}()
+	handshake := new(system.Handshake)
+	go func() {
+		errc <- p.dec.Decode(handshake)
+	}()
+
+	timeout := time.NewTimer(3 * time.Second)
+	defer timeout.Stop()
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errc:
+			if err != nil {
+				return err
+			}
+		case <-timeout.C:
+			return errors.New("handshake timed out")
+		}
+	}
+	// Find the common protocol, abort otherwise
+	if handshake.Protocol != pairing.Protocol {
+		return fmt.Errorf("unexpected pairing protocol: %s", handshake.Protocol)
+	}
+	var version uint
+	for _, v := range handshake.Versions {
+		if v == 1 { // Bit forced with only 1 supported version, should be better later
+			version = 1
+			break
+		}
+	}
+	if version == 0 {
+		return fmt.Errorf("no common protocol version: %v vs %v", []uint{1}, handshake.Protocol)
+	}
+	// Yay, handshake completed, run requested version
+	switch version {
+	case 1:
+		return p.handleV1()
+	default:
+		panic(fmt.Sprintf("unhandled pairing protocol version: %d", version))
+	}
+}
+
+// handleV1 is the handler for the v1 pairing protocol.
+//
+// See: https://github.com/coronanet/go-coronanet/blob/master/spec/wire.md
+func (p *pairer) handleV1() error {
+	blob, err := p.self.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+	// Send out identity, read theirs
+	errc := make(chan error, 2)
+	go func() {
+		errc <- p.enc.Encode(&pairing.Identity{Blob: blob})
+	}()
+	identity := new(pairing.Identity)
+	go func() {
+		errc <- p.dec.Decode(identity)
+	}()
+
+	timeout := time.NewTimer(3 * time.Second)
+	defer timeout.Stop()
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errc:
+			if err != nil {
+				return err
+			}
+		case <-timeout.C:
+			return errors.New("handshake timed out")
+		}
+	}
+	// Decode the received identity and return
+	id := new(tornet.PublicIdentity)
+	if err := id.UnmarshalJSON(identity.Blob); err != nil {
+		return err
+	}
+	p.peer = id
+	return nil
+}

--- a/pairer_test.go
+++ b/pairer_test.go
@@ -1,0 +1,51 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package coronanet
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/coronanet/go-coronanet/tornet"
+)
+
+// Tests that basic pairing works.
+func TestPairing(t *testing.T) {
+	// Create two identities, one for initiating pairing and one for joining
+	initKey, _ := tornet.GenerateIdentity()
+	joinKey, _ := tornet.GenerateIdentity()
+
+	// Initiate a pairing session and join it with the other identity
+	gateway := tornet.NewMockGateway()
+
+	initPairer, secret, err := newPairingServer(gateway, initKey.Public())
+	if err != nil {
+		t.Fatalf("failed to initiate pairing: %v", err)
+	}
+	joinPairer, err := newPairingClient(gateway, joinKey.Public(), secret)
+	if err != nil {
+		t.Fatalf("failed to join pairing: %v", err)
+	}
+	// Wait for both to finish
+	joinPub, err := initPairer.wait(context.TODO())
+	if err != nil {
+		t.Fatalf("server side pairing failed: %v", err)
+	}
+	initPub, err := joinPairer.wait(context.TODO())
+	if err != nil {
+		t.Fatalf("client side pairing failed: %v", err)
+	}
+	// Ensure the exchanged secrets match
+	initKeyBlob, _ := initKey.Public().MarshalJSON()
+	initPubBlob, _ := initPub.MarshalJSON()
+	if !bytes.Equal(initPubBlob, initKeyBlob) {
+		t.Errorf("initer key mismatch: have %x, want %x", initPubBlob, initKeyBlob)
+	}
+	joinKeyBlob, _ := joinKey.Public().MarshalJSON()
+	joinPubBlob, _ := joinPub.MarshalJSON()
+	if !bytes.Equal(joinPubBlob, joinKeyBlob) {
+		t.Errorf("joiner key mismatch: have %x, want %x", joinPubBlob, joinKeyBlob)
+	}
+}

--- a/protocol/corona/corona.go
+++ b/protocol/corona/corona.go
@@ -1,0 +1,25 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+// Package corona defines the messages for the main corona protocol.
+package corona
+
+// Protocol is the unique identifier of the corona protocol.
+const Protocol = "corona"
+
+// GetProfile requests the remote user's profile summary.
+type GetProfile struct{}
+
+// Profile sends the current user's profile summary.
+type Profile struct {
+	Name   string   // Free form name the user is advertising (might be fake)
+	Avatar [32]byte // SHA3 hash of the user's avatar (avoid download if known)
+}
+
+// GetAvatar requests the remote user's profile picture.
+type GetAvatar struct{}
+
+// Avatar sends the current user's profile picture.
+type Avatar struct {
+	Image []byte // Binary image content, mime not restricted for now
+}

--- a/protocol/pairing/pairing.go
+++ b/protocol/pairing/pairing.go
@@ -1,0 +1,15 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+// Package pairing defines the messages for side pairing.
+package pairing
+
+const (
+	// Protocol is the unique identifier of the pairing protocol.
+	Protocol = "pairing"
+)
+
+// Identity sends the user's Corona protocol P2P identity.
+type Identity struct {
+	Blob []byte // Encoded tornet public identity, internal format
+}

--- a/protocol/system/system.go
+++ b/protocol/system/system.go
@@ -1,0 +1,19 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+// Package system defines the messages for the base system protocol.
+package system
+
+// Handshake represents the initial protocol version negotiation.
+type Handshake struct {
+	Protocol string // Protocol expected on this connection
+	Versions []uint // Protocol version numbers supported
+}
+
+// Disconnect represents a notification that the connection is torn down.
+type Disconnect struct {
+	Reason string // Textual disconnect reason, meant for developers
+}
+
+// Heartbeat is a notification that the client is still alive.
+type Heartbeat struct{}

--- a/spec/wire.md
+++ b/spec/wire.md
@@ -1,0 +1,94 @@
+# Corona Network Protocol
+
+This document specifies the wire protocol format for the Corona Network's P2P infrastructure.
+
+The wire format is a Gob message protocol ([`encoding/gob`](https://golang.org/pkg/encoding/gob/)) on top of a stream protocol. We assume that peer identification, peer authorization and data encryption are already solved at the stream level. A Gob message stream has some intriguing properties:
+
+- The stream is self describing: all type information is passed along the data, but opposed to usual protocols that describe each and every message, Gob will only ever transmit type information once, at it's first occurrence.
+- Arbitrary Go types are supported: apart from certain limitations around `nil` pointers and circular references, almost anything can be encoded and decoded, without having to define the algorithm to do so.
+- Decoding is very forgiving: as the stream is self describing, message fields can be shuffled around; new ones added and old ones deleted. This permits many protocol changes to be done without duplicating message formats.
+
+## System Protocol
+
+The first message exchanged is the protocol handshake, which describes the capabilities of the peers to each other. The role of the handshake is to specify which protocol and which versions each can speak and choose the highest common one.
+
+The reason for including a protocol name too into the handshake is to allow certain connections to be used for completely different purposes than others. The current protocols are:
+
+- `corona`:  Main protocol used to maintain the social network 
+- `pairing`: Side protocol used to pair untrusted users together
+
+
+```go
+// Handshake represents the initial protocol version negotiation.
+type Handshake struct {
+	Protocol string // Protocol expected on this connection
+	Versions []uint // Protocol version numbers supported
+}
+```
+
+At any point in time during message exchange, either side can request the connection to be torn down. There is no pre-defined list of reasons that peers might give each other, rather only a free-form reason for developers:
+ 
+ - Programs can rarely meaningfully act on a disconnect reason. Generally they will just use their local knowledge to decide to reconnect or not, independent of what the remote side says.
+ - A predefined list of reasons always ends up being insufficient to describe all faults accurately. As such, developers end up reusing the same disconnect reason for a variety of cases, losing their meaning altogether.
+
+A disconnect code for programmatic interpretation can always be added later if there's a strong enough technical necessity for it.
+
+```go
+// Disconnect represents a notification that the connection is torn down.
+type Disconnect struct {
+    Reason string // Textual disconnect reason, meant for developers
+}
+```
+
+Peers should periodically send each other heartbeat messages. The role of these are to keep routing tables, NAT traversals and network circuits active; and also to detect if a remote side stopped responding.
+
+```go
+// Heartbeat is a notification that the client is still alive.
+type Heartbeat struct {}
+```
+
+## Corona Protocol v1 (draft)
+
+### User profile message
+
+The Corona Network features a mini social network with a very limited capability for users to announce and retrieve information about each other. The amount of profile information is deliberately super small to keep sensitive data out of the system; it's purpose is only to make certain UI tasks simpler.
+
+Users can request the remote side's profile information and will receive some basic infos and a summary of extended fields that would require costly retrievals.
+
+```go
+// GetProfile requests the remote user's profile summary.
+type GetProfile struct {}
+
+// Profile sends the current user's profile summary.
+type Profile struct {
+    Name   string   // Free form name the user is advertising (might be fake)
+    Avatar [32]byte // SHA3 hash of the user's avatar (avoid download if known)
+}
+```
+
+As seen above, the user's profile picture is not sent back in the response, to avoid downloading a large chunk of data only to realise it hasn't changed. Instead, it's SHA3 hash is returned, based on which the caller can decide to request or not. The profile picture retrieval is:
+
+```go
+// GetAvatar requests the remote user's profile picture.
+type GetAvatar struct {}
+
+// Avatar sends the current user's profile picture.
+type Avatar struct {
+    Image []byte // Binary image content, mime not restricted for now
+}
+```
+
+It is the callers sole discretion when it requests the profile / avatar from a remote connection. It might request it only after pairing and never again; it might do it once per connection; or maybe even periodically.
+
+## Pairing Protocol v1 (draft)
+
+The pairing protocol is a support mechanism disjoint from the main peer-to-peer protocol. It's purpose is to be an out-of-bounds secret-exchange between two nodes so they can share their identities and join each other on the main protocol.
+
+The protocol is overly simplistic because the underlying stream layer already provides authentication. As only public key exchange is needed in both directions, and nothing else, peers can just announce their data and disconnect afterwards.
+
+```go
+// Identity sends the user's Corona protocol P2P identity.
+type Identity struct {
+	Blob []byte // Encoded tornet public identity, internal format
+}
+```


### PR DESCRIPTION
This PR adds an initial draft protocol specification for the P2P layer (above tornet) and implements a PoC pairing mechanism. For now it uses a shared secret cert + TLS (should be shared secret + AES) to avoid having to implement a new crypto stream. Should be swapped out if the PoC proves workable.