### PR TITLE
coronanet, rest, spec: link up profile with gateway controls

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -47,6 +47,10 @@ func (b *Backend) Enable() error {
 	if b.proxy != nil {
 		return nil
 	}
+	// Ensure we have a crypto profile available
+	if _, err := b.Profile(); err != nil {
+		return err
+	}
 	// Create the Tor background process and let it bootstrap itself async.
 	proxy, err := tor.Start(nil, &tor.StartConf{
 		ProcessCreator:         libtor.Creator,

--- a/cmd/coronanet/main.go
+++ b/cmd/coronanet/main.go
@@ -10,22 +10,29 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/coronanet/go-coronanet"
 	"github.com/coronanet/go-coronanet/rest"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
-	datadirFlag = flag.String("datadir", ".", "Data directory for the backend")
-	portFlag    = flag.Int("port", 4444, "TCP port to launch the API server on")
+	datadirFlag   = flag.String("datadir", ".", "Data directory for the backend")
+	apiportFlag   = flag.Int("apiport", 4444, "TCP port to launch the API server on")
+	verbosityFlag = flag.Int("verbosity", int(log.LvlInfo), "Log level to run with")
 )
 
 func main() {
 	flag.Parse()
 
+	// Enable colored terminal logging
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*verbosityFlag), log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+
+	// Create a live backend and expose via REST
 	backend, err := coronanet.NewBackend(*datadirFlag)
 	if err != nil {
 		panic(err)
 	}
-	http.ListenAndServe(fmt.Sprintf("localhost:%d", *portFlag), rest.New(backend))
+	http.ListenAndServe(fmt.Sprintf("localhost:%d", *apiportFlag), rest.New(backend))
 }

--- a/profile.go
+++ b/profile.go
@@ -21,6 +21,10 @@ var (
 	// ErrProfileExists is returned if a new profile is attempted to be created
 	// but an old one already exists.
 	ErrProfileExists = errors.New("profile already exists")
+
+	// ErrGatewayEnabled is returned if the profile is attempted to be deleted,
+	// but the gateway is actively using it.
+	ErrGatewayEnabled = errors.New("gateway enabled")
 )
 
 // profile represents a local user's profile information, both public and private.
@@ -54,7 +58,13 @@ func (b *Backend) CreateProfile() error {
 func (b *Backend) DeleteProfile() error {
 	// Retrieve the current profile and abort if it doesn't exist
 	if _, err := b.Profile(); err != nil {
+		return nil
+	}
+	// If the gateway is enabled, we cannot pull the data from underneath
+	if enabled, _, _, _, err := b.Status(); err != nil {
 		return err
+	} else if enabled {
+		return ErrGatewayEnabled
 	}
 	// Profile existed, nuke the database
 	it := b.database.NewIterator(&util.Range{nil, nil}, nil)

--- a/rest/profile.go
+++ b/rest/profile.go
@@ -67,7 +67,7 @@ func (api *api) serveProfileInfo(w http.ResponseWriter, r *http.Request) {
 		}
 		switch err := api.backend.UpdateProfile(profile.Name); err {
 		case coronanet.ErrProfileNotFound:
-			http.Error(w, "Local user doesn't exist", http.StatusUnauthorized)
+			http.Error(w, "Local user doesn't exist", http.StatusForbidden)
 		case nil:
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -77,8 +77,8 @@ func (api *api) serveProfileInfo(w http.ResponseWriter, r *http.Request) {
 	case "DELETE":
 		// Deletes the local user (nukes all data)
 		switch err := api.backend.DeleteProfile(); err {
-		case coronanet.ErrProfileNotFound:
-			http.Error(w, "Local user doesn't exist", http.StatusUnauthorized)
+		case coronanet.ErrGatewayEnabled:
+			http.Error(w, "Gateway is using profile", http.StatusForbidden)
 		case nil:
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -97,7 +97,7 @@ func (api *api) serveProfileAvatar(w http.ResponseWriter, r *http.Request, path 
 		// Retrieves the local user's profile and redirect to the immutable URL
 		switch profile, err := api.backend.Profile(); {
 		case err == coronanet.ErrProfileNotFound:
-			http.Error(w, "Local user doesn't exist", http.StatusUnauthorized)
+			http.Error(w, "Local user doesn't exist", http.StatusForbidden)
 		case err == nil && profile.Avatar == [32]byte{}:
 			http.Error(w, "Local user doesn't have a profile picture", http.StatusNotFound)
 		case err == nil:
@@ -124,7 +124,7 @@ func (api *api) serveProfileAvatar(w http.ResponseWriter, r *http.Request, path 
 		// Attempt to push the image into the database
 		switch err := api.backend.UploadProfilePicture(buffer.Bytes()); err {
 		case coronanet.ErrProfileNotFound:
-			http.Error(w, "Local user doesn't exist", http.StatusUnauthorized)
+			http.Error(w, "Local user doesn't exist", http.StatusForbidden)
 		case nil:
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -135,7 +135,7 @@ func (api *api) serveProfileAvatar(w http.ResponseWriter, r *http.Request, path 
 		// Deletes the local user's profile picture
 		switch err := api.backend.DeleteProfile(); err {
 		case coronanet.ErrProfileNotFound:
-			http.Error(w, "Local user doesn't exist", http.StatusUnauthorized)
+			http.Error(w, "Local user doesn't exist", http.StatusForbidden)
 		case nil:
 			w.WriteHeader(http.StatusOK)
 		default:

--- a/rest/profile.go
+++ b/rest/profile.go
@@ -76,14 +76,11 @@ func (api *api) serveProfileInfo(w http.ResponseWriter, r *http.Request) {
 
 	case "DELETE":
 		// Deletes the local user (nukes all data)
-		switch err := api.backend.DeleteProfile(); err {
-		case coronanet.ErrGatewayEnabled:
-			http.Error(w, "Gateway is using profile", http.StatusForbidden)
-		case nil:
-			w.WriteHeader(http.StatusOK)
-		default:
+		if err := api.backend.DeleteProfile(); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
+		w.WriteHeader(http.StatusOK)
 
 	default:
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)

--- a/spec/api.yaml
+++ b/spec/api.yaml
@@ -117,8 +117,6 @@ paths:
       tags:
         - Profile
       responses:
-        403:
-          description: Gateway is using profile
         200:
           description: Successfully deleted user
 

--- a/spec/api.yaml
+++ b/spec/api.yaml
@@ -63,9 +63,10 @@ paths:
       tags:
         - Gateway
       responses:
+        403:
+          description: Cannot join the Corona Network without a local user
         200:
           description: Network connection will be established async and actively maintained
-          content: {}
     delete:
       summary: Requests the gateway to disconnect from the Corona Network
       tags:
@@ -73,7 +74,6 @@ paths:
       responses:
         200:
           description: Network connection torn down
-          content: {}
 
   /profile:
     post:
@@ -108,7 +108,7 @@ paths:
       responses:
         400:
           description: Provided profile is invalid
-        401:
+        403:
           description: Local user doesn't exist
         200:
           description: User profile updated
@@ -117,8 +117,8 @@ paths:
       tags:
         - Profile
       responses:
-        401:
-          description: Local user doesn't exist
+        403:
+          description: Gateway is using profile
         200:
           description: Successfully deleted user
 
@@ -128,7 +128,7 @@ paths:
       tags:
         - Profile
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Local user doesn't have a profile picture
@@ -141,7 +141,7 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/Avatar'
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         200:
           description: User profile picture updated
@@ -150,7 +150,7 @@ paths:
       tags:
         - Profile
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         200:
           description: Successfully deleted the local user's profile picture
@@ -161,7 +161,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         200:
           description: Returns a list of contact IDs
@@ -185,7 +185,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Remote contact is unknown
@@ -203,7 +203,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Profile'
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Remote contact is unknown
@@ -214,7 +214,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Remote contact is unknown
@@ -234,7 +234,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Remote contact is unknown
@@ -247,7 +247,7 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/Avatar'
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Remote contact is unknown
@@ -258,7 +258,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         404:
           description: Remote contact is unknown
@@ -271,7 +271,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         200:
           description: Successfully created pairing session
@@ -294,7 +294,7 @@ paths:
       tags:
         - Contacts
       responses:
-        401:
+        403:
           description: Local user doesn't exist
         200:
           description: Successfully established session

--- a/tornet/tornet.go
+++ b/tornet/tornet.go
@@ -158,9 +158,8 @@ func (node *Node) start(serve bool, dial bool) error {
 	var err error
 	if serve {
 		config := &tor.ListenConf{
-			Key:         node.owner.onion,
-			RemotePorts: []int{1},
-			Version3:    true,
+			Key:      node.owner.onion,
+			Version3: true,
 		}
 		node.onion, err = node.gateway.Listen(context.Background(), config)
 		if err != nil {


### PR DESCRIPTION
This PR attempts to link together profile (and crypto key) creation with the Tor identity, gateway control and tornet onion listeners. Everything kind of works well, except the hang that's documented in https://github.com/coronanet/go-coronanet/issues/16.