### PR TITLE
all: implement end-to-end pairing workflow

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -25,6 +25,7 @@ type Backend struct {
 	network  *tor.Tor    // Proxy through the Tor network, nil when offline
 
 	overlay *tornet.Node // Overlay network running the Corona protocol
+	pairing *pairer      // Currently active pairing session (nil if none)
 
 	lock sync.RWMutex
 }
@@ -75,7 +76,7 @@ func (b *Backend) Enable() error {
 	if err := b.network.EnableNetwork(context.Background(), false); err != nil {
 		return nil
 	}
-	overlay := tornet.New(tornet.NewTorGateway(b.network), prof.Key, map[string]*tornet.PublicIdentity{}, nil)
+	overlay := tornet.New(tornet.NewTorGateway(b.network), prof.Key, prof.Ring, nil)
 	if err := overlay.Start(); err != nil {
 		// Something went wrong, tear down the Tor circuits. TODO(karalabe): upstream as `b.network.DisableNetwork`?
 		if err := b.network.Control.SetConf(control.KeyVals("DisableNetwork", "1")...); err != nil {

--- a/contacts.go
+++ b/contacts.go
@@ -1,0 +1,21 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package coronanet
+
+import "github.com/coronanet/go-coronanet/tornet"
+
+// AddContact inserts a new remote identity into the local trust ring and adds
+// it to the overlay network.
+func (b *Backend) AddContact(id *tornet.PublicIdentity) error {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	if err := b.addContact(id); err != nil {
+		return err
+	}
+	if b.overlay == nil {
+		return nil
+	}
+	return b.overlay.Trust(id.ID(), id)
+}

--- a/pairing.go
+++ b/pairing.go
@@ -1,0 +1,86 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package coronanet
+
+import (
+	"context"
+	"errors"
+
+	"github.com/coronanet/go-coronanet/tornet"
+)
+
+var (
+	// ErrNetworkDisabled is returned if an operation is requested which requires
+	// network access but it is not enabled.
+	ErrNetworkDisabled = errors.New("network disabled")
+
+	// ErrAlreadyPairing is returned if a pairing session is attempted to be
+	// initiated, but one is already in progress.
+	ErrAlreadyPairing = errors.New("already pairing")
+
+	// ErrNotPairing is returned if a pairing session is attempted to be joined,
+	// but none is in progress.
+	ErrNotPairing = errors.New("not pairing")
+)
+
+// InitPairing initiates a new pairing session over Tor.
+func (b *Backend) InitPairing() (*tornet.SecretIdentity, error) {
+	// Ensure there is no pairing session ongoing
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.overlay == nil {
+		return nil, ErrNetworkDisabled
+	}
+	if b.pairing != nil {
+		return nil, ErrAlreadyPairing
+	}
+	// No pairing session running, create a new one
+	prof, err := b.Profile()
+	if err != nil {
+		panic(err) // Overlay cannot exist without a profile
+	}
+	pairer, secret, err := newPairingServer(tornet.NewTorGateway(b.network), prof.Key.Public())
+	if err != nil {
+		return nil, err
+	}
+	b.pairing = pairer
+	return secret, nil
+}
+
+// WaitPairing blocks until an already initiated pairing session is joined.
+func (b *Backend) WaitPairing() (*tornet.PublicIdentity, error) {
+	// Ensure there is a pairing session ongoing
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.pairing == nil {
+		return nil, ErrNotPairing
+	}
+	// Pairing session in progress, wait for it and tear it down
+	id, err := b.pairing.wait(context.TODO())
+	b.pairing = nil
+	return id, err
+}
+
+// JoinPairing joins a remotely initiated pairing session.
+func (b *Backend) JoinPairing(secret *tornet.SecretIdentity) (*tornet.PublicIdentity, error) {
+	// Ensure we are in a pairable state
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	if b.overlay == nil {
+		return nil, ErrNetworkDisabled
+	}
+	prof, err := b.Profile()
+	if err != nil {
+		panic(err) // Overlay cannot exist without a profile
+	}
+	// Join the remote pairing session and return the results
+	pairer, err := newPairingClient(tornet.NewTorGateway(b.network), prof.Key.Public(), secret)
+	if err != nil {
+		return nil, err
+	}
+	return pairer.wait(context.TODO())
+}

--- a/rest/pairing.go
+++ b/rest/pairing.go
@@ -1,0 +1,86 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/coronanet/go-coronanet"
+	"github.com/coronanet/go-coronanet/tornet"
+)
+
+// servePairing serves API calls concerning the contact pairing.
+func (api *api) servePairing(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "POST":
+		// Creates a pairing session for contact establishment
+		switch secret, err := api.backend.InitPairing(); err {
+		case coronanet.ErrNetworkDisabled:
+			http.Error(w, "Cannot pair while offline", http.StatusForbidden)
+		case nil:
+			w.Header().Add("Content-Type", "application/json")
+
+			blob, _ := json.Marshal(secret)
+			json.NewEncoder(w).Encode(blob) // Bit unorthodox, but we don't want callers to interpret the data
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	case "GET":
+		// Waits for a pairing session to complete
+		switch id, err := api.backend.WaitPairing(); err {
+		case coronanet.ErrNotPairing:
+			http.Error(w, "No pairing session in progress", http.StatusForbidden)
+		case nil:
+			// Pairing succeeded, try to inject the contact into the backend
+			switch err := api.backend.AddContact(id); err {
+			case coronanet.ErrContactExists:
+				http.Error(w, "Remote contact already paired", http.StatusConflict)
+			case nil:
+				w.Header().Add("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(id.ID())
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	case "PUT":
+		// Waits for a pairing session to complete
+
+		// Read the pairing secret from the command line
+		var blob []byte
+		if err := json.NewDecoder(r.Body).Decode(&blob); err != nil { // Bit unorthodox, but we don't want callers to interpret the data
+			http.Error(w, "Provided pairing secret is invalid: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		secret := new(tornet.SecretIdentity)
+		if err := secret.UnmarshalJSON(blob); err != nil {
+			http.Error(w, "Provided pairing secret is invalid: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		switch id, err := api.backend.JoinPairing(secret); err {
+		case coronanet.ErrNetworkDisabled:
+			http.Error(w, "Cannot pair while offline", http.StatusForbidden)
+		case nil:
+			// Pairing succeeded, try to inject the contact into the backend
+			switch err := api.backend.AddContact(id); err {
+			case coronanet.ErrContactExists:
+				http.Error(w, "Remote contact already paired", http.StatusConflict)
+			case nil:
+				w.Header().Add("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(id.ID())
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}

--- a/rest/service.go
+++ b/rest/service.go
@@ -33,6 +33,8 @@ func (api *api) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		api.serveGateway(w, r)
 	case strings.HasPrefix(r.URL.Path, "/profile"):
 		api.serveProfile(w, r, strings.TrimPrefix(r.URL.Path, "/profile"))
+	case strings.HasPrefix(r.URL.Path, "/pairing"):
+		api.servePairing(w, r)
 	case strings.HasPrefix(r.URL.Path, "/cdn"):
 		api.serveCDN(w, r, strings.TrimPrefix(r.URL.Path, "/cdn"))
 	default:

--- a/spec/api.yaml
+++ b/spec/api.yaml
@@ -153,6 +153,64 @@ paths:
         200:
           description: Successfully deleted the local user's profile picture
 
+  /pairing:
+    post:
+      summary: Creates a pairing session for contact establishment
+      tags:
+        - Contacts
+      responses:
+        403:
+          description: Cannot pair while offline
+        200:
+          description: Successfully created pairing session
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Temporary pairing secret
+    get:
+      summary: Waits for a pairing session to complete
+      tags:
+        - Contacts
+      responses:
+        403:
+          description: No pairing session in progress
+        409:
+          description: Remote contact already paired
+        200:
+          description: Successfully established session
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Contact ID of the paired user
+    put:
+      summary: Joins a pairing session for contact establishment
+      tags:
+        - Contacts
+      requestBody:
+        description: Optional description in *Markdown*
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              description: Temporary pairing secret
+      responses:
+        400:
+          description: Provided pairing secret is invalid
+        403:
+          description: Cannot pair while offline
+        409:
+          description: Remote contact already paired
+        200:
+          description: Successfully established session
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Contact ID of the paired user
+
   /contacts:
     get:
       summary: List all contacts of the local user
@@ -262,45 +320,6 @@ paths:
           description: Remote contact is unknown
         200:
           description: Successfully removed override
-
-  /pairing:
-    post:
-      summary: Creates a pairing session for contact establishment
-      tags:
-        - Contacts
-      responses:
-        403:
-          description: Local user doesn't exist
-        200:
-          description: Successfully created pairing session
-          content:
-            application/json:
-              schema:
-                type: string
-                description: Temporary pairing secret
-
-  /pairing/{secret}:
-    parameters:
-      - name: secret
-        in: path
-        required: true
-        description: Secret returned from POST to /pairing
-        schema:
-          type: string
-    put:
-      summary: Joins a pairing session for contact establishment
-      tags:
-        - Contacts
-      responses:
-        403:
-          description: Local user doesn't exist
-        200:
-          description: Successfully established session
-          content:
-            application/json:
-              schema:
-                type: string
-                description: Contact ID of the paired user
 
   /cdn/images/{sha3}:
     get:

--- a/tornet/crypto.go
+++ b/tornet/crypto.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cretz/bine/torutil/ed25519"
+	"golang.org/x/crypto/sha3"
 )
 
 // SecretIdentity is a tuple consisting of a permanent certificate identifying the
@@ -147,6 +148,13 @@ func (id *SecretIdentity) trash() error {
 type PublicIdentity struct {
 	owner []byte
 	onion ed25519.PublicKey
+}
+
+// ID returns a short, globally unique identifier for this public key. Essentially
+// it is the SHA3 hash of the owner certificate.
+func (id *PublicIdentity) ID() string {
+	hash := sha3.Sum256(id.owner)
+	return string(hash[:])
 }
 
 // MarshalJSON implements the json.Marshaller interface, encoding the entire public

--- a/tornet/tornet.go
+++ b/tornet/tornet.go
@@ -158,8 +158,9 @@ func (node *Node) start(serve bool, dial bool) error {
 	var err error
 	if serve {
 		config := &tor.ListenConf{
-			Key:      node.owner.onion,
-			Version3: true,
+			Key:         node.owner.onion,
+			RemotePorts: []int{1},
+			Version3:    true,
 		}
 		node.onion, err = node.gateway.Listen(context.Background(), config)
 		if err != nil {


### PR DESCRIPTION
This PR implements the end-to-end pairing workflow across REST -> coronanet -> Tor. There's nothing done after pairing succeed (apart from a crash because there's no network handler on the P2P overlay). Still, the PR is standalone.