### PR TITLE
all: end-to-end contact profile and avatar exchange

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -5,7 +5,6 @@ package coronanet
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -42,8 +41,8 @@ func NewBackend(datadir string) (*Backend, error) {
 		ProcessCreator:         libtor.Creator,
 		UseEmbeddedControlConn: true,
 		DataDir:                filepath.Join(datadir, "tor"),
-		DebugWriter:            os.Stderr,
-		NoHush:                 true,
+		//DebugWriter:            os.Stderr,
+		//NoHush:                 true,
 	})
 	if err != nil {
 		db.Close()
@@ -76,7 +75,7 @@ func (b *Backend) Enable() error {
 	if err := b.network.EnableNetwork(context.Background(), false); err != nil {
 		return nil
 	}
-	overlay := tornet.New(tornet.NewTorGateway(b.network), prof.Key, prof.Ring, nil)
+	overlay := tornet.New(tornet.NewTorGateway(b.network), prof.Key, prof.Ring, b.handleContact)
 	if err := overlay.Start(); err != nil {
 		// Something went wrong, tear down the Tor circuits. TODO(karalabe): upstream as `b.network.DisableNetwork`?
 		if err := b.network.Control.SetConf(control.KeyVals("DisableNetwork", "1")...); err != nil {

--- a/contacts.go
+++ b/contacts.go
@@ -3,19 +3,147 @@
 
 package coronanet
 
-import "github.com/coronanet/go-coronanet/tornet"
+import (
+	"encoding/json"
+
+	"github.com/coronanet/go-coronanet/tornet"
+)
+
+var (
+	// dbContactPrefix is the database key for storing a remote user's profile.
+	dbContactPrefix = []byte("contact-")
+)
+
+// contact represents a remote user's profile information.
+type contact struct {
+	Name   string   `json:"name`    // Originally remote, can override
+	Avatar [32]byte `json:"avatar"` // Always remote, for now
+}
 
 // AddContact inserts a new remote identity into the local trust ring and adds
 // it to the overlay network.
-func (b *Backend) AddContact(id *tornet.PublicIdentity) error {
+func (b *Backend) AddContact(id *tornet.PublicIdentity) (string, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	// Inject the security credentials into the local profile and create the profile
+	// entry for the remote user.
+	uid := id.ID()
+	if err := b.addContact(id); err != nil {
+		return "", err
+	}
+	blob, err := json.Marshal(&contact{})
+	if err != nil {
+		return "", err
+	}
+	if err := b.database.Put(append(dbContactPrefix, uid...), blob, nil); err != nil {
+		return "", err
+	}
+	// If the overlay network is currently online, enable networking with this user
+	if b.overlay == nil {
+		return uid, nil
+	}
+	return uid, b.overlay.Trust(uid, id)
+}
+
+// Contacts returns the unique ids of all the current contacts.
+func (b *Backend) Contacts() ([]string, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	if err := b.addContact(id); err != nil {
+	prof, err := b.Profile()
+	if err != nil {
+		return nil, ErrProfileNotFound
+	}
+	ids := make([]string, 0, len(prof.Ring))
+	for id := range prof.Ring {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// Contact retrieves a remote user's profile infos.
+func (b *Backend) Contact(id string) (*contact, error) {
+	blob, err := b.database.Get(append(dbContactPrefix, id...), nil)
+	if err != nil {
+		return nil, ErrContactNotFound
+	}
+	info := new(contact)
+	if err := json.Unmarshal(blob, info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// UpdateContact overrides the profile information of an existing remote user.
+func (b *Backend) UpdateContact(id string, name string) error {
+	// Retrieve the current profile and abort if the update is a noop
+	info, err := b.Contact(id)
+	if err != nil {
 		return err
 	}
-	if b.overlay == nil {
+	if info.Name == name {
 		return nil
 	}
-	return b.overlay.Trust(id.ID(), id)
+	// Name changed, update and serialize back to disk
+	info.Name = name
+
+	blob, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	return b.database.Put(append(dbContactPrefix, id...), blob, nil)
+}
+
+// uploadContactPicture uploads a new local profile picture for the remote user.
+func (b *Backend) uploadContactPicture(id string, data []byte) error {
+	// Retrieve the current profile to ensure the user exists
+	info, err := b.Contact(id)
+	if err != nil {
+		return err
+	}
+	// Upload the image into the CDN and delete the old one
+	hash, err := b.uploadCDNImage(data)
+	if err != nil {
+		return err
+	}
+	if info.Avatar != ([32]byte{}) {
+		if err := b.deleteCDNImage(info.Avatar); err != nil {
+			return err
+		}
+	}
+	// If the hash changed, update the profile
+	if info.Avatar == hash {
+		return nil
+	}
+	info.Avatar = hash
+
+	blob, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	return b.database.Put(append(dbContactPrefix, id...), blob, nil)
+}
+
+// deleteContactPicture deletes the existing local profile picture of the remote user.
+func (b *Backend) deleteContactPicture(id string) error {
+	// Retrieve the current profile to ensure the user exists
+	info, err := b.Contact(id)
+	if err != nil {
+		return err
+	}
+	if info.Avatar == [32]byte{} {
+		return nil
+	}
+	// Profile picture exists, delete it from the CDN and update the profile
+	if err := b.deleteCDNImage(info.Avatar); err != nil {
+		return err
+	}
+	info.Avatar = [32]byte{}
+
+	blob, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	return b.database.Put(append(dbContactPrefix, id...), blob, nil)
 }

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,203 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package coronanet
+
+import (
+	"encoding/gob"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/coronanet/go-coronanet/protocol/corona"
+	"github.com/coronanet/go-coronanet/protocol/system"
+	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/crypto/sha3"
+)
+
+// coronaMessage is an envelope containing all possible messages received through
+// the Corona Network wire protocol.
+type coronaMessage struct {
+	Handshake  *system.Handshake
+	Disconnect *system.Disconnect
+	GetProfile *corona.GetProfile
+	Profile    *corona.Profile
+	GetAvatar  *corona.GetAvatar
+	Avatar     *corona.Avatar
+}
+
+// handleContact is ran when a remote contact connects to us via the tornet.
+func (b *Backend) handleContact(id string, conn net.Conn) error {
+	// Create a logger to track what's going on
+	logger := log.New("contact", id[:8])
+	logger.Info("Contact connected")
+
+	// Create the gob encoder and decoder
+	enc := gob.NewEncoder(conn)
+	dec := gob.NewDecoder(conn)
+
+	// Run the protocol handshake and catch any errors. Since we're not yet in
+	// the separate reader/writer phase, we can't send over errors. Just nuke
+	// the connection.
+	ver, err := b.handleContactHandshake(enc, dec)
+	if err != nil {
+		logger.Warn("Protocol handshake failed", "err", err)
+		return err
+	}
+	// Common protocol version negotiated, start up the actual message handler
+	switch ver {
+	case 1:
+		// Version one will do a profile exchange on connect
+		go enc.Encode(&coronaMessage{GetProfile: &corona.GetProfile{}})
+		err := b.handleContactV1(logger, id, enc, dec)
+		if err != nil {
+			// Something failed horribly, try to send over an error
+			conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
+			enc.Encode(&coronaMessage{Disconnect: &system.Disconnect{Reason: err.Error()}})
+		}
+		logger.Warn("Connection torn down", "err", err)
+		return err
+	default:
+		panic(fmt.Sprintf("unhandled corona protocol version: %d", ver))
+	}
+}
+
+// handleContactHandshake runs the `corona` protocol negotiation and returns the
+// common version number agreed upon.
+func (b *Backend) handleContactHandshake(enc *gob.Encoder, dec *gob.Decoder) (uint, error) {
+	// All protocols start with a system handshake, send ours, read theirs
+	errc := make(chan error, 2)
+	go func() {
+		errc <- enc.Encode(&coronaMessage{
+			Handshake: &system.Handshake{Protocol: corona.Protocol, Versions: []uint{1}},
+		})
+	}()
+	message := new(coronaMessage)
+	go func() {
+		errc <- dec.Decode(message)
+	}()
+	timeout := time.NewTimer(3 * time.Second)
+	defer timeout.Stop()
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errc:
+			if err != nil {
+				return 0, err
+			}
+		case <-timeout.C:
+			return 0, errors.New("handshake timed out")
+		}
+	}
+	// Find the common protocol, abort otherwise
+	if message.Handshake == nil {
+		return 0, fmt.Errorf("handshake missing from first message")
+	}
+	handshake := message.Handshake
+	if handshake.Protocol != corona.Protocol {
+		return 0, fmt.Errorf("unexpected corona protocol: %s", handshake.Protocol)
+	}
+	var version uint
+	for _, v := range handshake.Versions {
+		if v == 1 { // Bit forced with only 1 supported version, should be better later
+			version = 1
+			break
+		}
+	}
+	if version == 0 {
+		return 0, fmt.Errorf("no common protocol version: %v vs %v", []uint{1}, handshake.Protocol)
+	}
+	return version, nil
+}
+
+// handleContactV1 is ran when a remote contact connects to us via the tornet
+// and negotiates a common `corona` protocol version of 1.
+func (b *Backend) handleContactV1(logger log.Logger, id string, enc *gob.Encoder, dec *gob.Decoder) error {
+	for {
+		// Read the next message off the network
+		message := new(coronaMessage)
+		if err := dec.Decode(message); err != nil {
+			return err
+		}
+		// Depending on what we've got, do something meaningful
+		switch {
+		case message.Handshake != nil:
+			logger.Warn("Contact sent double handshake")
+			return errors.New("unexpected handshake")
+
+		case message.Disconnect != nil:
+			if message.Disconnect.Reason != "" {
+				logger.Warn("Contact dropped connection", "reason", message.Disconnect.Reason)
+			}
+			return nil
+
+		case message.GetProfile != nil:
+			logger.Info("Contact requested profile")
+			prof, err := b.Profile()
+			if err != nil {
+				panic(err) // Profile must exist for networking
+			}
+			if err := enc.Encode(&coronaMessage{Profile: &corona.Profile{
+				Name:   prof.Name,
+				Avatar: prof.Avatar,
+			}}); err != nil {
+				return err
+			}
+
+		case message.Profile != nil:
+			logger.Info("Contact sent profile", "name", message.Profile.Name, "avatar", hex.EncodeToString(message.Profile.Avatar[:]))
+
+			// Update the profile name if initial exchange, ignore otherwise
+			info, err := b.Contact(id)
+			if err != nil {
+				panic(err) // Profile must exist for this handler to run
+			}
+			if info.Name == "" {
+				logger.Info("Setting initial name")
+				if err := b.UpdateContact(id, message.Profile.Name); err != nil {
+					// Well, shit. Not much we can do, ignore and run with it
+					logger.Warn("Failed to set initial name", "err", err)
+				}
+			} else if info.Name != message.Profile.Name {
+				logger.Info("Rejecting remote name change", "have", info.Name)
+			}
+			// If the avatar was changed, request te new one
+			if info.Avatar != message.Profile.Avatar {
+				go enc.Encode(&coronaMessage{GetAvatar: &corona.GetAvatar{}})
+			}
+
+		case message.GetAvatar != nil:
+			logger.Info("Contact requested avatar")
+			prof, err := b.Profile()
+			if err != nil {
+				panic(err) // Profile must exist for networking
+			}
+			if prof.Avatar == ([32]byte{}) {
+				// No avatar set, sorry
+				logger.Info("No avatar to send over", "err", err)
+				go enc.Encode(&coronaMessage{Avatar: &corona.Avatar{Image: []byte{}}})
+				continue
+			}
+			img, err := b.CDNImage(prof.Avatar)
+			if err != nil {
+				// Something funky happened, warn and nuke the remote image
+				logger.Warn("Local avatar unavailable", "err", err)
+				go enc.Encode(&coronaMessage{Avatar: &corona.Avatar{Image: []byte{}}})
+				continue
+			}
+			if err := enc.Encode(&coronaMessage{Avatar: &corona.Avatar{Image: img}}); err != nil {
+				return err
+			}
+
+		case message.Avatar != nil:
+			hash := sha3.Sum256(message.Avatar.Image)
+
+			logger.Info("Contact sent avatar", "hash", hex.EncodeToString(hash[:]), "bytes", len(message.Avatar.Image))
+			if err := b.uploadContactPicture(id, message.Avatar.Image); err != nil {
+				logger.Warn("Failed to set avatar", "err", err)
+			}
+		}
+	}
+	return nil
+}

--- a/pairer.go
+++ b/pairer.go
@@ -103,7 +103,6 @@ func (p *pairer) handle(id string, conn net.Conn) (err error) {
 	p.dec = gob.NewDecoder(conn)
 
 	// Make sure the connection is torn down but send any errors
-	defer conn.Close()
 	defer func() {
 		if err != nil {
 			p.failure = err

--- a/profile.go
+++ b/profile.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	// dbProfileKey is the database key for storing the local user's profile.
 	dbProfileKey = []byte("profile")
 
 	// ErrProfileNotFound is returned if the profile is attempted to be read from
@@ -26,7 +27,7 @@ var (
 	// but it is the local user.
 	ErrSelfContact = errors.New("cannot contact self")
 
-	// ErrContactNotFound is returned if a new contact is attempted to be deleted
+	// ErrContactNotFound is returned if a new contact is attempted to be accessed
 	// but it does not exist.
 	ErrContactNotFound = errors.New("contact not found")
 

--- a/rest/contacts.go
+++ b/rest/contacts.go
@@ -1,0 +1,118 @@
+// go-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/coronanet/go-coronanet"
+)
+
+// serveContacts serves API calls concerning all contacts.
+func (api *api) serveContacts(w http.ResponseWriter, r *http.Request, path string) {
+	// If we're not serving the contacts root, descend into a single contact
+	if path != "" {
+		api.serveContact(w, r, path)
+		return
+	}
+	// Handle serving the contacts root
+	switch r.Method {
+	case "GET":
+		// List all contacts of the local user
+		switch contacts, err := api.backend.Contacts(); err {
+		case coronanet.ErrProfileNotFound:
+			http.Error(w, "Local user doesn't exist", http.StatusForbidden)
+		case nil:
+			w.Header().Add("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(contacts)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+// serveContact serves API calls concerning a single remote contact.
+func (api *api) serveContact(w http.ResponseWriter, r *http.Request, path string) {
+	// All contact APIs need to provide the unique id
+	if len(path) < 65 || (len(path) > 65 && path[65] != '/') {
+		http.Error(w, "Contact ID invalid", http.StatusBadRequest)
+		return
+	}
+	api.serveContactProfile(w, r, path[1:65], path[65:])
+}
+
+// serveContactProfile serves API calls concerning a remote contact profile.
+func (api *api) serveContactProfile(w http.ResponseWriter, r *http.Request, id string, path string) {
+	switch {
+	case path == "/profile":
+		api.serveContactProfileInfo(w, r, id)
+	case strings.HasPrefix(path, "/profile/avatar"):
+		api.serveContactProfileAvatar(w, r, id)
+	default:
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}
+}
+
+// serveContactProfileInfo serves API calls concerning the local user's profile infos.
+func (api *api) serveContactProfileInfo(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case "GET":
+		// Retrieves a remote contact's profile
+		switch contact, err := api.backend.Contact(id); err {
+		case coronanet.ErrContactNotFound:
+			http.Error(w, "Remote contact doesn't exist", http.StatusNotFound)
+		case nil:
+			w.Header().Add("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(&profileInfos{Name: contact.Name})
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	case "PUT":
+		// Overrides the remote contact's profile
+		profile := new(profileInfos)
+		if err := json.NewDecoder(r.Body).Decode(profile); err != nil {
+			http.Error(w, "Provided profile is invalid: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		switch err := api.backend.UpdateContact(id, profile.Name); err {
+		case coronanet.ErrContactNotFound:
+			http.Error(w, "Remote contact doesn't exist", http.StatusForbidden)
+		case nil:
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}
+
+// serveContactProfileAvatar serves API calls concerning a remote user's profile picture.
+func (api *api) serveContactProfileAvatar(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case "GET":
+		// Retrieves the remote contact's profile and redirect to the immutable URL
+		switch contact, err := api.backend.Contact(id); {
+		case err == coronanet.ErrContactNotFound:
+			http.Error(w, "Remote contact doesn't exist", http.StatusForbidden)
+		case err == nil && contact.Avatar == [32]byte{}:
+			http.Error(w, "Remote contact doesn't have a profile picture", http.StatusNotFound)
+		case err == nil:
+			http.Redirect(w, r, fmt.Sprintf("/cdn/images/%x", contact.Avatar), http.StatusFound)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+}

--- a/rest/pairing.go
+++ b/rest/pairing.go
@@ -35,12 +35,12 @@ func (api *api) servePairing(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "No pairing session in progress", http.StatusForbidden)
 		case nil:
 			// Pairing succeeded, try to inject the contact into the backend
-			switch err := api.backend.AddContact(id); err {
+			switch uid, err := api.backend.AddContact(id); err {
 			case coronanet.ErrContactExists:
 				http.Error(w, "Remote contact already paired", http.StatusConflict)
 			case nil:
 				w.Header().Add("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(id.ID())
+				json.NewEncoder(w).Encode(uid)
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
@@ -67,12 +67,12 @@ func (api *api) servePairing(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Cannot pair while offline", http.StatusForbidden)
 		case nil:
 			// Pairing succeeded, try to inject the contact into the backend
-			switch err := api.backend.AddContact(id); err {
+			switch uid, err := api.backend.AddContact(id); err {
 			case coronanet.ErrContactExists:
 				http.Error(w, "Remote contact already paired", http.StatusConflict)
 			case nil:
 				w.Header().Add("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(id.ID())
+				json.NewEncoder(w).Encode(uid)
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}

--- a/rest/service.go
+++ b/rest/service.go
@@ -35,6 +35,8 @@ func (api *api) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		api.serveProfile(w, r, strings.TrimPrefix(r.URL.Path, "/profile"))
 	case strings.HasPrefix(r.URL.Path, "/pairing"):
 		api.servePairing(w, r)
+	case strings.HasPrefix(r.URL.Path, "/contacts"):
+		api.serveContacts(w, r, strings.TrimPrefix(r.URL.Path, "/contacts"))
 	case strings.HasPrefix(r.URL.Path, "/cdn"):
 		api.serveCDN(w, r, strings.TrimPrefix(r.URL.Path, "/cdn"))
 	default:

--- a/spec/api.yaml
+++ b/spec/api.yaml
@@ -241,10 +241,8 @@ paths:
       tags:
         - Contacts
       responses:
-        403:
-          description: Local user doesn't exist
         404:
-          description: Remote contact is unknown
+          description: Remote contact doesn't exist
         200:
           $ref: '#/components/responses/Profile'
     put:
@@ -259,23 +257,12 @@ paths:
             schema:
               $ref: '#/components/schemas/Profile'
       responses:
+        400:
+          description: Provided profile is invalid
         403:
-          description: Local user doesn't exist
-        404:
-          description: Remote contact is unknown
+          description: Remote contact doesn't exist
         200:
           description: Contact profile updated
-    delete:
-      summary: Remove the remote contact profile override
-      tags:
-        - Contacts
-      responses:
-        403:
-          description: Local user doesn't exist
-        404:
-          description: Remote contact is unknown
-        200:
-          description: Successfully removed override
 
   /contacts/{id}/profile/avatar:
     parameters:
@@ -296,30 +283,6 @@ paths:
           description: Remote contact is unknown
         302:
           $ref: '#/components/responses/Avatar'
-    put:
-      summary: Overrides a remote contact's profile picture
-      tags:
-        - Contacts
-      requestBody:
-        $ref: '#/components/requestBodies/Avatar'
-      responses:
-        403:
-          description: Local user doesn't exist
-        404:
-          description: Remote contact is unknown
-        200:
-          description: Contact profile picture updated
-    delete:
-      summary: Deletes a remote contact's profile picture
-      tags:
-        - Contacts
-      responses:
-        403:
-          description: Local user doesn't exist
-        404:
-          description: Remote contact is unknown
-        200:
-          description: Successfully removed override
 
   /cdn/images/{sha3}:
     get:
@@ -372,6 +335,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Profile'
+
     Avatar:
       description: Redirect to immutable image
       content:

--- a/spec/wire.md
+++ b/spec/wire.md
@@ -66,6 +66,8 @@ type Profile struct {
 }
 ```
 
+Although clients will always return the name too in their response, this field may (read, generally will) be ignored to avoid faking someone else.
+
 As seen above, the user's profile picture is not sent back in the response, to avoid downloading a large chunk of data only to realise it hasn't changed. Instead, it's SHA3 hash is returned, based on which the caller can decide to request or not. The profile picture retrieval is:
 
 ```go
@@ -92,3 +94,7 @@ type Identity struct {
 	Blob []byte // Encoded tornet public identity, internal format
 }
 ```
+
+Notes:
+
+- The `v1` pairing protocol is overly simplistic for prototyping reasons. Future versions need to implement some profile exchange and confirmation too to ensure that you are talking to the correct person **before** trusting them with access to your (public) keys.

--- a/tornet/crypto.go
+++ b/tornet/crypto.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -151,10 +152,10 @@ type PublicIdentity struct {
 }
 
 // ID returns a short, globally unique identifier for this public key. Essentially
-// it is the SHA3 hash of the owner certificate.
+// it is the SHA3 hash of the owner certificate in hexadecimal form.
 func (id *PublicIdentity) ID() string {
 	hash := sha3.Sum256(id.owner)
-	return string(hash[:])
+	return hex.EncodeToString(hash[:])
 }
 
 // MarshalJSON implements the json.Marshaller interface, encoding the entire public


### PR DESCRIPTION
This PR completes the initial v0 PoC prototype, adding end-to-end contact info and avatar exchange. The contact infos are only ever exchanged on first connection (yeah, prototype), so you'll need to `disable` the node and `enable` it back to force a new exchange.